### PR TITLE
community: correct typo in semanticscholar.py

### DIFF
--- a/libs/community/langchain_community/utilities/semanticscholar.py
+++ b/libs/community/langchain_community/utilities/semanticscholar.py
@@ -80,7 +80,7 @@ class SemanticScholarAPIWrapper(BaseModel):
                 f"Published year: {getattr(item, 'year', None)}\n"
                 f"Title: {getattr(item, 'title', None)}\n"
                 f"Authors: {authors}\n"
-                f"Astract: {getattr(item, 'abstract', None)}\n"
+                f"Abstract: {getattr(item, 'abstract', None)}\n"
             )
 
         if documents:


### PR DESCRIPTION
Update "astract" to abstract. The retrieved list of papers comes with of typo of "astract" under published year, title and authors